### PR TITLE
Added D-Link DWA-127

### DIFF
--- a/src/common/rtusb_dev_id.c
+++ b/src/common/rtusb_dev_id.c
@@ -43,6 +43,7 @@ USB_DEVICE_ID rtusb_dev_id[] = {
 	{USB_DEVICE(0x148f,0x7601)}, /* MT 6370 */
 	{USB_DEVICE(0x148f,0x760b)}, /* 360 wifi 2 */
 	{USB_DEVICE(0x2717,0x4106)}, /* XiaoMi wifi */
+	{USB_DEVICE(0x2001,0x3d04)}, /* D-Link DWA-127 */	
 #endif /* MT7601U */
 	{ }/* Terminating entry */
 };


### PR DESCRIPTION
D-Link DWA-127 works as access point as well.
Tested on RasPi 3, kernel 4.4.36.